### PR TITLE
Allow Binder usage in provider's `register` method

### DIFF
--- a/src/BindingServiceProvider.php
+++ b/src/BindingServiceProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace MichaelRubel\AutoBinder;
 
+use Illuminate\Cache\CacheServiceProvider;
 use MichaelRubel\AutoBinder\Commands\AutoBinderClearCommand;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
@@ -22,5 +23,15 @@ class BindingServiceProvider extends PackageServiceProvider
         $package
             ->name('laravel-auto-binder')
             ->hasCommand(AutoBinderClearCommand::class);
+    }
+
+    /**
+     * @return void
+     */
+    public function packageRegistered(): void
+    {
+        if (! app()->bound('cache')) {
+            app()->register(CacheServiceProvider::class, true);
+        }
     }
 }

--- a/src/BindingServiceProvider.php
+++ b/src/BindingServiceProvider.php
@@ -28,7 +28,7 @@ class BindingServiceProvider extends PackageServiceProvider
     /**
      * @return void
      */
-    public function packageRegistered(): void
+    public function registeringPackage(): void
     {
         if (! app()->bound('cache')) {
             app()->register(CacheServiceProvider::class, true);

--- a/tests/AutoBindingTest.php
+++ b/tests/AutoBindingTest.php
@@ -3,9 +3,12 @@
 namespace MichaelRubel\AutoBinder\Tests;
 
 use MichaelRubel\AutoBinder\AutoBinder;
+use MichaelRubel\AutoBinder\BindingServiceProvider;
 use MichaelRubel\AutoBinder\Commands\AutoBinderClearCommand;
 use MichaelRubel\AutoBinder\Tests\Boilerplate\Models\Example;
 use MichaelRubel\AutoBinder\Tests\Boilerplate\Models\Interfaces\ExampleInterface;
+use MichaelRubel\AutoBinder\Tests\Boilerplate\Providers\BootServiceProvider;
+use MichaelRubel\AutoBinder\Tests\Boilerplate\Providers\RegisterServiceProvider;
 use MichaelRubel\AutoBinder\Tests\Boilerplate\Services\AnotherService;
 use MichaelRubel\AutoBinder\Tests\Boilerplate\Services\Contracts\ExampleServiceContract;
 use MichaelRubel\AutoBinder\Tests\Boilerplate\Services\ExampleService;
@@ -341,5 +344,27 @@ class AutoBindingTest extends TestCase
             ->bind();
 
         $this->assertTrue(cache()->has(AutoBinder::CACHE_KEY . 'Services'));
+    }
+
+    /** @test */
+    public function testCanUseAutoBinderInRegisterProvidersMethod()
+    {
+        app()->offsetUnset('cache');
+        app()->register(BindingServiceProvider::class, true);
+        app()->register(RegisterServiceProvider::class);
+
+        $this->assertTrue(app()->bound(ExampleServiceInterface::class));
+        $this->assertInstanceOf(ExampleService::class, app(ExampleServiceInterface::class));
+    }
+
+    /** @test */
+    public function testCanUseAutoBinderInBootProvidersMethod()
+    {
+        app()->offsetUnset('cache');
+        app()->register(BindingServiceProvider::class, true);
+        app()->register(BootServiceProvider::class);
+
+        $this->assertTrue(app()->bound(ExampleServiceInterface::class));
+        $this->assertInstanceOf(ExampleService::class, app(ExampleServiceInterface::class));
     }
 }

--- a/tests/Boilerplate/Providers/BootServiceProvider.php
+++ b/tests/Boilerplate/Providers/BootServiceProvider.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MichaelRubel\AutoBinder\Tests\Boilerplate\Providers;
+
+use Illuminate\Support\ServiceProvider;
+use MichaelRubel\AutoBinder\AutoBinder;
+
+class BootServiceProvider extends ServiceProvider
+{
+    /**
+     * @return void
+     */
+    public function boot(): void
+    {
+        AutoBinder::from(folder: 'Services')
+            ->basePath('tests/Boilerplate')
+            ->classNamespace('MichaelRubel\\AutoBinder\\Tests\\Boilerplate')
+            ->interfaceNamespace('MichaelRubel\\AutoBinder\\Tests\\Boilerplate\\Services\\Interfaces')
+            ->as('singleton')
+            ->bind();
+    }
+}

--- a/tests/Boilerplate/Providers/RegisterServiceProvider.php
+++ b/tests/Boilerplate/Providers/RegisterServiceProvider.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MichaelRubel\AutoBinder\Tests\Boilerplate\Providers;
+
+use Illuminate\Support\ServiceProvider;
+use MichaelRubel\AutoBinder\AutoBinder;
+
+class RegisterServiceProvider extends ServiceProvider
+{
+    /**
+     * @return void
+     */
+    public function register(): void
+    {
+        AutoBinder::from(folder: 'Services')
+            ->basePath('tests/Boilerplate')
+            ->classNamespace('MichaelRubel\\AutoBinder\\Tests\\Boilerplate')
+            ->interfaceNamespace('MichaelRubel\\AutoBinder\\Tests\\Boilerplate\\Services\\Interfaces')
+            ->as('singleton')
+            ->bind();
+    }
+}


### PR DESCRIPTION
## About
This PR adds a possibility of `AutoBinder` usage in the provider's registering process (`register` method), removing the requirement to use it only in the `boot` method. We make sure Laravel's cache binding is available during the package's bootstrapping process.

```php
public function register(): void
{
    AutoBinder::from(folder: 'Services')
        ->as('singleton')
        ->bind();
}
```