### PR TITLE
Avoid throwing exception in the clear command 🔧

### DIFF
--- a/src/Commands/AutoBinderClearCommand.php
+++ b/src/Commands/AutoBinderClearCommand.php
@@ -5,7 +5,6 @@ namespace MichaelRubel\AutoBinder\Commands;
 use Illuminate\Cache\Repository;
 use Illuminate\Console\Command;
 use Illuminate\Support\Collection;
-use InvalidArgumentException;
 use MichaelRubel\AutoBinder\AutoBinder;
 
 class AutoBinderClearCommand extends Command

--- a/src/Commands/AutoBinderClearCommand.php
+++ b/src/Commands/AutoBinderClearCommand.php
@@ -31,7 +31,9 @@ class AutoBinderClearCommand extends Command
             $clue = $this->getClueFor($folder);
 
             if (! $cache->has($clue)) {
-                throw new InvalidArgumentException('Cached folder ' . $folder . ' not found.');
+                $this->warn('Cached folder ' . $folder . ' not found.');
+
+                return;
             }
 
             $this->flushContainerBindings($cache, $clue);

--- a/tests/CacheTest.php
+++ b/tests/CacheTest.php
@@ -141,11 +141,8 @@ class CacheTest extends TestCase
     /** @test */
     public function testCannotClearCacheForNonExistingFolders()
     {
-        try {
-            $this->artisan(AutoBinderClearCommand::class, ['folder' => 'Test']);
-        } catch (\InvalidArgumentException $e) {
-            $this->assertSame('Cached folder Test not found.', $e->getMessage());
-        }
+        $this->artisan(AutoBinderClearCommand::class, ['folder' => 'Test'])
+            ->expectsOutput('Cached folder Test not found.');
     }
 
     /** @test */


### PR DESCRIPTION
## About

This PR changes the behavior of the cache clear command to avoid throwing an exception in case of a not found folder.

---